### PR TITLE
Find any README file name 

### DIFF
--- a/__tests__/rampUpTime.test.ts
+++ b/__tests__/rampUpTime.test.ts
@@ -1,104 +1,90 @@
-
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { JSDOM } from 'jsdom';
-import { getDocumentationScore } from '../src/rampUpTime.ts'; // Adjust the import path
+import { getDocumentationScore, calculateRampUpScore } from '../src/rampUpTime.ts'; // Adjust the import path
 import * as utils from '../src/utils';
 
-// Mock the `gitHubRequest` and `JSDOM` dependencies
-vi.mock('./path-to-utils', () => ({
-    gitHubRequest: vi.fn(),
+vi.mock('./utils.js', () => ({
+  gitHubRequest: vi.fn(),
+  logMessage: vi.fn(),
 }));
 
-// Mock `JSDOM` properly
-vi.mock('jsdom', () => ({
-    JSDOM: vi.fn().mockImplementation((html: string) => ({
-        window: {
-            document: {
-                body: {
-                    textContent: html
-                }
+const mockRepoOwner = "testOwner";
+const mockRepoName = "testRepo";
+
+describe('Documentation Scoring', () => {
+  
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return the correct documentation score when a README-like file is found', async () => {
+    const mockResponse = {
+      repository: {
+        object: {
+          entries: [
+            {
+              name: "README.md",
+              type: "blob",
+              object: {
+                text: "# Project\n\n## Installation\n\nInstructions for installation.\n## Usage\n\nHow to use the project.\n## API\n\nAPI documentation.\n## Examples\n\nCode examples."
+              }
             }
+          ]
         }
-    })),
-}));
+      }
+    };
 
-describe('getDocumentationScore', () => {
-    afterEach(() => {
-        // Restore all mocks after each test
-        vi.restoreAllMocks();
-    });
-    it('should return a score based on README content', async () => {
-        const repoOwner = 'exampleOwner';
-        const repoName = 'exampleRepo';
+    vi.spyOn(utils, 'gitHubRequest').mockResolvedValue(mockResponse);
 
-        vi.spyOn(utils, 'gitHubRequest').mockResolvedValue({
-          repository: {
-            object: {
-                text: `
-                    # Project
-                    ## Installation
-                    Instructions for installation.
-                    ## Usage
-                    How to use the project.
-                    ## API
-                    API documentation.
-                    ## Examples
-                    Code examples.
-                `
+    const score = await getDocumentationScore(mockRepoOwner, mockRepoName);
+    
+    expect(score).toBe(1); // All keywords present, so score is 1
+  });
+
+  it('should return DEFAULT_SCORE when no README-like file is found', async () => {
+    const mockResponse = {
+      repository: {
+        object: {
+          entries: []
+        }
+      }
+    };
+
+    vi.spyOn(utils, 'gitHubRequest').mockResolvedValue(mockResponse);
+
+    const score = await getDocumentationScore(mockRepoOwner, mockRepoName);
+
+    expect(score).toBe(0); // No README-like file found, score is DEFAULT_SCORE
+  });
+
+  it('should handle errors gracefully and return DEFAULT_SCORE', async () => {
+    vi.spyOn(utils, 'gitHubRequest').mockRejectedValue(new Error("Network error"));
+
+    const score = await getDocumentationScore(mockRepoOwner, mockRepoName);
+
+    expect(score).toBe(0); // Error occurred, score is DEFAULT_SCORE
+  });
+
+  it('should calculate the overall Ramp-Up Time Score', async () => {
+    const mockResponse = {
+      repository: {
+        object: {
+          entries: [
+            {
+              name: "README.md",
+              type: "blob",
+              object: {
+                text: "# Project\n\n## Installation\n\nInstructions for installation.\n## Usage\n\nHow to use the project."
+              }
             }
+          ]
         }
-        });
+      }
+    };
 
-        // Mock `JSDOM` to simulate parsing of README content
-        const mockJSDOM = new JSDOM(`
-            <body>
-                <h1>Project</h1>
-                <h2>Installation</h2>
-                <p>Instructions for installation.</p>
-                <h2>Usage</h2>
-                <p>How to use the project.</p>
-                <h2>API</h2>
-                <p>API documentation.</p>
-                <h2>Examples</h2>
-                <p>Code examples.</p>
-            </body>
-        `);
-        vi.mocked(JSDOM).mockImplementation(() => mockJSDOM);
+    vi.spyOn(utils, 'gitHubRequest').mockResolvedValue(mockResponse);
 
-        // Call the function and check the result
-        const score = await getDocumentationScore(repoOwner, repoName);
-        expect(score).toBe(1); // All keywords are present, so the score should be 1
-    });
+    const score = await calculateRampUpScore(mockRepoOwner, mockRepoName);
 
-    it('should return 0 if README does not contain any keywords', async () => {
-        const repoOwner = 'exampleOwner';
-        const repoName = 'exampleRepo';
-
-        vi.spyOn(utils, 'gitHubRequest').mockResolvedValue({
-          repository: {
-            object: {
-                text: 'This README does not contain the specified keywords.'
-            }
-        }
-        });
-
-        // Mock `JSDOM` to simulate parsing of README content
-        const mockJSDOM = new JSDOM('<body>This README does not contain the specified keywords.</body>');
-        vi.mocked(JSDOM).mockImplementation(() => mockJSDOM);
-
-        // Call the function and check the result
-        const score = await getDocumentationScore(repoOwner, repoName);
-        expect(score).toBe(0);
-    });
-
-    it('should return 0 if there is an error fetching README', async () => {
-        const repoOwner = 'exampleOwner';
-        const repoName = 'exampleRepo';
-
-        vi.spyOn(utils, 'gitHubRequest').mockRejectedValue(new Error('Network Error'));
-
-        // Call the function and check the result
-        const score = await getDocumentationScore(repoOwner, repoName);
-        expect(score).toBe(0);
-    });
+    expect(score).toBe(0.5); // 3 out of 6 keywords present (installation, usage, api, examples)
+  });
 });


### PR DESCRIPTION
This pull requests address's team 5's open issue about Identifying README files with unusual names. This fix finds any file containing readme in the name, instead of just files titles exactly README.md. This fix in turn corrects the RampUp calculation for those repos that have an unusual readme name. 